### PR TITLE
Use `isearch-forward-thing-at-point` to customise behaviour of `thing-at-point`

### DIFF
--- a/isearch-mb.el
+++ b/isearch-mb.el
@@ -42,13 +42,14 @@
   "Control isearch from the minibuffer."
   :group 'isearch)
 
-(defcustom isearch-mb-thing-at-point '(region url symbol sexp line)
-  "A list of symbols to try to get the \"thing\" at point.
+(unless (boundp 'isearch-forward-thing-at-point)
+  (defcustom isearch-forward-thing-at-point '(region url symbol sexp)
+    "A list of symbols to try to get the \"thing\" at point.
 Each element of the list should be one of the symbols supported by
-`bounds-of-thing-at-point'.  This variable is used by isearch-mb
-to yank the initial \"thing\" as text to the search string."
-  :group 'isearch-mb
-  :type '(repeat (symbol :tag "Thing symbol")))
+`bounds-of-thing-at-point'.  This variable is used by the command
+`isearch-forward-thing-at-point' to yank the initial \"thing\"
+as text to the search string."
+    :type '(repeat (symbol :tag "Thing symbol"))))
 
 (defvar isearch-mb--with-buffer
   '(isearch-beginning-of-buffer

--- a/isearch-mb.el
+++ b/isearch-mb.el
@@ -42,15 +42,6 @@
   "Control isearch from the minibuffer."
   :group 'isearch)
 
-(unless (boundp 'isearch-forward-thing-at-point)
-  (defcustom isearch-forward-thing-at-point '(region url symbol sexp)
-    "A list of symbols to try to get the \"thing\" at point.
-Each element of the list should be one of the symbols supported by
-`bounds-of-thing-at-point'.  This variable is used by the command
-`isearch-forward-thing-at-point' to yank the initial \"thing\"
-as text to the search string."
-    :type '(repeat (symbol :tag "Thing symbol"))))
-
 (defvar isearch-mb--with-buffer
   '(isearch-beginning-of-buffer
     isearch-end-of-buffer
@@ -226,11 +217,13 @@ minibuffer."
                     isearch-mb-minibuffer-map
                     nil
                     (if isearch-regexp 'regexp-search-ring 'search-ring)
-                    (thread-last isearch-forward-thing-at-point
-                                 (mapcar #'thing-at-point)
-                                 (delq nil)
-                                 (delete-dups)
-                                 (mapcar (if isearch-regexp 'regexp-quote 'identity)))
+                    (thread-last (if (boundp isearch-forward-thing-at-point)
+                                     isearch-forward-thing-at-point
+                                     '(region url symbol sexp))
+                      (mapcar #'thing-at-point)
+                      (delq nil)
+                      (delete-dups)
+                      (mapcar (if isearch-regexp 'regexp-quote 'identity)))
                     t)
                    ;; Undo a possible recenter after quitting the minibuffer.
                    (set-window-start nil wstart))

--- a/isearch-mb.el
+++ b/isearch-mb.el
@@ -217,13 +217,13 @@ minibuffer."
                     isearch-mb-minibuffer-map
                     nil
                     (if isearch-regexp 'regexp-search-ring 'search-ring)
-                    (thread-last (if (boundp isearch-forward-thing-at-point)
+                    (thread-last (if (boundp 'isearch-forward-thing-at-point)
                                      isearch-forward-thing-at-point
                                      '(region url symbol sexp))
-                      (mapcar #'thing-at-point)
-                      (delq nil)
-                      (delete-dups)
-                      (mapcar (if isearch-regexp 'regexp-quote 'identity)))
+                                 (mapcar #'thing-at-point)
+                                 (delq nil)
+                                 (delete-dups)
+                                 (mapcar (if isearch-regexp 'regexp-quote 'identity)))
                     t)
                    ;; Undo a possible recenter after quitting the minibuffer.
                    (set-window-start nil wstart))

--- a/isearch-mb.el
+++ b/isearch-mb.el
@@ -225,11 +225,11 @@ minibuffer."
                     isearch-mb-minibuffer-map
                     nil
                     (if isearch-regexp 'regexp-search-ring 'search-ring)
-                    (thread-last isearch-mb-thing-at-point
-                      (mapcar #'thing-at-point)
-                      (delq nil)
-                      (delete-dups)
-                      (mapcar (if isearch-regexp 'regexp-quote 'identity)))
+                    (thread-last isearch-forward-thing-at-point
+                                 (mapcar #'thing-at-point)
+                                 (delq nil)
+                                 (delete-dups)
+                                 (mapcar (if isearch-regexp 'regexp-quote 'identity)))
                     t)
                    ;; Undo a possible recenter after quitting the minibuffer.
                    (set-window-start nil wstart))

--- a/isearch-mb.el
+++ b/isearch-mb.el
@@ -42,6 +42,14 @@
   "Control isearch from the minibuffer."
   :group 'isearch)
 
+(defcustom isearch-mb-thing-at-point '(region url symbol sexp line)
+  "A list of symbols to try to get the \"thing\" at point.
+Each element of the list should be one of the symbols supported by
+`bounds-of-thing-at-point'.  This variable is used by isearch-mb
+to yank the initial \"thing\" as text to the search string."
+  :group 'isearch-mb
+  :type '(repeat (symbol :tag "Thing symbol")))
+
 (defvar isearch-mb--with-buffer
   '(isearch-beginning-of-buffer
     isearch-end-of-buffer
@@ -217,7 +225,7 @@ minibuffer."
                     isearch-mb-minibuffer-map
                     nil
                     (if isearch-regexp 'regexp-search-ring 'search-ring)
-                    (thread-last '(region url symbol sexp line) ;; TODO: make customizable
+                    (thread-last isearch-mb-thing-at-point
                       (mapcar #'thing-at-point)
                       (delq nil)
                       (delete-dups)


### PR DESCRIPTION
Hi there,
I saw there was a `TODO` for making the list of 'things' isearch-mb tries to find to add to the default history items customizable, so I went ahead and did that.  The docstring and name of the variable are mostly just copied from `isearch-forward-thing-at-point`.  I have been using a certain major mode in which `thing-at-point` is quite slow, and had been using a redefined version of `isearch-mb--session` to disable `thing-at-point`, but this seems like a nicer, cleaner solution, and more people could benefit from it.  For my usage I intend to set the new variable to just `region`.  I have signed the FSF copyright assignment papers so assuming you're OK with this PR, that shouldn't be a barrier to getting it merged.
Please let me know what you think!