### PR TITLE
Fix issue with isearch--describe-regexp-mode returning nil

### DIFF
--- a/isearch-mb.el
+++ b/isearch-mb.el
@@ -163,8 +163,9 @@
                    (concat count ;; Count is padded so that it only grows.
                            (make-string (max 0 (- len (length count))) ?\ )
                            (capitalize
-                            (isearch--describe-regexp-mode
-                             isearch-regexp-function)))))))
+                            (or (isearch--describe-regexp-mode
+                                 isearch-regexp-function)
+                                "")))))))
 
 (defun isearch-mb--add-defaults ()
   "Add default search strings to future history."

--- a/isearch-mb.el
+++ b/isearch-mb.el
@@ -154,18 +154,10 @@
 (defun isearch-mb--update-prompt (&rest _)
   "Update the minibuffer prompt according to search status."
   (when isearch-mb--prompt-overlay
-    (let ((count (isearch-lazy-count-format))
-          (len (or (overlay-get isearch-mb--prompt-overlay 'isearch-mb--len) 0)))
-      (overlay-put isearch-mb--prompt-overlay
-                   'isearch-mb--len (max len (length count)))
-      (overlay-put isearch-mb--prompt-overlay
-                   'before-string
-                   (concat count ;; Count is padded so that it only grows.
-                           (make-string (max 0 (- len (length count))) ?\ )
-                           (capitalize
-                            (or (isearch--describe-regexp-mode
-                                 isearch-regexp-function)
-                                "")))))))
+    (overlay-put isearch-mb--prompt-overlay
+                 'before-string
+		 (propertize (isearch-message-prefix)
+			     'face '(:inverse-video nil :inherit minibuffer-prompt)))))
 
 (defun isearch-mb--add-defaults ()
   "Add default search strings to future history."
@@ -236,7 +228,7 @@ minibuffer."
                            nil 'local)
                  (setq-local tool-bar-map isearch-tool-bar-map)
                  (setq isearch-mb--prompt-overlay (make-overlay (point-min) (point-min)
-                                                                (current-buffer) t t))
+                                                                (current-buffer) nil t))
                  (isearch-mb--update-prompt)
                  (isearch-mb--post-command-hook))
              (unwind-protect
@@ -246,7 +238,7 @@ minibuffer."
                    (dolist (fun isearch-mb--after-exit)
                      (advice-add fun :around #'isearch-mb--after-exit))
                    (read-from-minibuffer
-                    "I-search: " nil isearch-mb-minibuffer-map nil
+                    "" nil isearch-mb-minibuffer-map nil
                     (if isearch-regexp 'regexp-search-ring 'search-ring) nil t)
                    ;; Undo a possible recenter after quitting the minibuffer.
                    (set-window-start nil wstart))

--- a/isearch-mb.el
+++ b/isearch-mb.el
@@ -154,10 +154,15 @@
 (defun isearch-mb--update-prompt (&rest _)
   "Update the minibuffer prompt according to search status."
   (when isearch-mb--prompt-overlay
-    (overlay-put isearch-mb--prompt-overlay
-                 'before-string
-		 (propertize (isearch-message-prefix)
-			     'face '(:inverse-video nil :inherit minibuffer-prompt)))))
+    (let ((message-prefix (isearch-message-prefix)))
+      ;; Don't make the prompt inverse-video when the text is.
+      (add-face-text-property 0 (length message-prefix)
+                              '(:inverse-video nil)
+                              nil
+                              message-prefix)
+      (overlay-put isearch-mb--prompt-overlay
+                   'before-string
+                   message-prefix))))
 
 (defun isearch-mb--add-defaults ()
   "Add default search strings to future history."


### PR DESCRIPTION
Hi Augusto, thanks for writing this package! Started using it and wanted to contribute a small bugfix:

`isearch--describe-regexp-mode` can sometimes return `nil` when `regexp-function` is set but is a lambda function. This is the relevant except from isearch.el:
```elisp
(defun isearch--describe-regexp-mode (regexp-function &optional space-before)
  "Make a string for describing REGEXP-FUNCTION.
If SPACE-BEFORE is non-nil, put a space before, instead of after,
the word mode."
  (when (eq regexp-function t)
    (setq regexp-function #'word-search-regexp))
  (let ((description
         (cond
          ;; 1. Do not use a description on the default search mode,
          ;;    but only if the default search mode is non-nil.
          ((and (or (and search-default-mode
                         (equal search-default-mode regexp-function))
                    ;; Special case where `search-default-mode' is t
                    ;; (defaults to regexp searches).
                    (and (eq search-default-mode t)
                         (eq search-default-mode isearch-regexp)))
                ;; Also do not omit description in case of error
                ;; in default non-literal search.
                (or isearch-success (not (or regexp-function isearch-regexp))))
           "")
          ;; 2. Use the `isearch-message-prefix' set for
          ;;    `regexp-function' if available.
          (regexp-function
           (and (symbolp regexp-function)
                (or (get regexp-function 'isearch-message-prefix)
                    "")))
          ;; 3. Else if `isearch-regexp' is non-nil, set description
          ;;    to "regexp ".
          (isearch-regexp "regexp ")
          ;; 4. Else if we're in literal mode (and if the default
          ;;    mode is also not literal), describe it.
          ((functionp search-default-mode) "literal ")
          ;; 5. And finally, if none of the above is true, set the
          ;;    description to an empty string.
          (t ""))))
    (if space-before
        ;; Move space from the end to the beginning.
        (replace-regexp-in-string "\\(.*\\) \\'" " \\1" description)
      description)))
```

This would lead to `isearch-mb--update-prompt` erroring out because it would try to capitalize `nil`. Added a small fix which uses an empty string as default for when `isearch--describe-regexp-mode` does return nil.